### PR TITLE
Remove GMCM Deprecation Warning + Update to .net6 + Add toggle config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -391,3 +391,4 @@ FodyWeavers.xsd
 *.msix
 *.msm
 *.msp
+GiveMeMyCursorBack/Build/Build.targets

--- a/GiveMeMyCursorBack/Config.cs
+++ b/GiveMeMyCursorBack/Config.cs
@@ -2,6 +2,7 @@
 {
     public class Config
     {
+        public bool Enabled { get; set; } = true;
         public int TickThreshold { get; set; } = 10;
     }
 }

--- a/GiveMeMyCursorBack/GiveMeMyCursorBack.csproj
+++ b/GiveMeMyCursorBack/GiveMeMyCursorBack.csproj
@@ -1,75 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-    <PropertyGroup>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <ProjectGuid>{696FE4A5-8016-4124-9B2D-88345AA6DD4A}</ProjectGuid>
-        <OutputType>Library</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
-        <RootNamespace>GiveMeMyCursorBack</RootNamespace>
-        <AssemblyName>GiveMeMyCursorBack</AssemblyName>
-        <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-        <FileAlignment>512</FileAlignment>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <DebugSymbols>true</DebugSymbols>
-        <DebugType>full</DebugType>
-        <Optimize>false</Optimize>
-        <OutputPath>bin\Debug\</OutputPath>
-        <DefineConstants>DEBUG;TRACE</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <DebugType>pdbonly</DebugType>
-        <Optimize>true</Optimize>
-        <OutputPath>bin\Release\</OutputPath>
-        <DefineConstants>TRACE</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-    </PropertyGroup>
-    <ItemGroup>
-        <Reference Include="Microsoft.Build" />
-        <Reference Include="Microsoft.Build.Framework" />
-        <Reference Include="Microsoft.Build.Utilities.v4.0" />
-        <Reference Include="System" />
-        <Reference Include="System.Core" />
-        <Reference Include="System.Data" />
-        <Reference Include="System.IO.Compression" />
-        <Reference Include="System.Web.Extensions" />
-        <Reference Include="System.Xml" />
-    </ItemGroup>
-    <ItemGroup>
-        <Compile Include="Config.cs" />
-        <Compile Include="GiveMyMeCursorBackEntry.cs" />
-        <Compile Include="Helpers\IGenericModConfigMenuApi.cs" />
-        <Compile Include="Properties\AssemblyInfo.cs" />
-    </ItemGroup>
-    <ItemGroup>
-      <Content Include="Build\Build.targets" />
-      <Content Include="manifest.json" />
-    </ItemGroup>
-    <ItemGroup>
-      <None Include="packages.config" />
-    </ItemGroup>
-    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-    <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.3.3.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.3.3.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
-    <Import Project="Build\Build.targets" />
-    <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-      <PropertyGroup>
-        <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
-      </PropertyGroup>
-      <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.3.3.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.3.3.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-    </Target>
-    <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-         Other similar extension points exist, see Microsoft.Common.targets.
-    <Target Name="BeforeBuild">
-    </Target>
-    <Target Name="AfterBuild">
-    </Target>
-    -->
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+	<BundleExtraAssemblies>ThirdParty</BundleExtraAssemblies>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.1.1" />
+  </ItemGroup>
 
 </Project>

--- a/GiveMeMyCursorBack/GiveMyMeCursorBackEntry.cs
+++ b/GiveMeMyCursorBack/GiveMyMeCursorBackEntry.cs
@@ -40,6 +40,14 @@ namespace GiveMeMyCursorBack
                     mod: ModManifest,
                     text: () => "Get your cursor back!");
 
+                gmcm.AddBoolOption(
+                    mod: ModManifest,
+                    name: () => "Enable?",
+                    tooltip: () => "Allows you to toggle on and off the mod's cursor abilities",
+                    getValue: () => _config.Enabled,
+                    setValue: value => _config.Enabled = value
+                );
+
                 gmcm.AddParagraph(
                     mod: ModManifest,
                     text: () =>
@@ -64,6 +72,9 @@ namespace GiveMeMyCursorBack
 
         private void OnUpdateTicked(object sender, UpdateTickedEventArgs e)
         {
+            if (!_config.Enabled)
+                return;
+
             _tickCounter++;
 
             if (_tickCounter < _config.TickThreshold)

--- a/GiveMeMyCursorBack/GiveMyMeCursorBackEntry.cs
+++ b/GiveMeMyCursorBack/GiveMyMeCursorBackEntry.cs
@@ -3,7 +3,6 @@ using GenericModConfigMenu;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewValley;
-using StardewValley.Minigames;
 
 namespace GiveMeMyCursorBack
 {

--- a/GiveMeMyCursorBack/Helpers/IGenericModConfigMenuApi.cs
+++ b/GiveMeMyCursorBack/Helpers/IGenericModConfigMenuApi.cs
@@ -34,7 +34,7 @@ namespace GenericModConfigMenu
         /// <param name="mod">The mod's manifest.</param>
         /// <param name="text">The paragraph text to display.</param>
         void AddParagraph(IManifest mod, Func<string> text);
-        
+
         /// <summary>Add an integer option at the current position in the form.</summary>
         /// <param name="mod">The mod's manifest.</param>
         /// <param name="getValue">Get the current value from the mod config.</param>
@@ -44,11 +44,8 @@ namespace GenericModConfigMenu
         /// <param name="min">The minimum allowed value, or <c>null</c> to allow any.</param>
         /// <param name="max">The maximum allowed value, or <c>null</c> to allow any.</param>
         /// <param name="interval">The interval of values that can be selected.</param>
+        /// <param name="formatValue">Get the display text to show for a value, or <c>null</c> to show the number as-is.</param>
         /// <param name="fieldId">The unique field ID for use with <see cref="OnFieldChanged"/>, or <c>null</c> to auto-generate a randomized ID.</param>
-        void AddNumberOption(IManifest mod, Func<int> getValue, Action<int> setValue, Func<string> name, Func<string> tooltip = null, int? min = null, int? max = null, int? interval = null, string fieldId = null);
-
-        /// <summary>Remove a mod from the config UI and delete all its options and pages.</summary>
-        /// <param name="mod">The mod's manifest.</param>
-        void Unregister(IManifest mod);
+        void AddNumberOption(IManifest mod, Func<int> getValue, Action<int> setValue, Func<string> name, Func<string> tooltip = null, int? min = null, int? max = null, int? interval = null, Func<int, string> formatValue = null, string fieldId = null);
     }
 }

--- a/GiveMeMyCursorBack/Helpers/IGenericModConfigMenuApi.cs
+++ b/GiveMeMyCursorBack/Helpers/IGenericModConfigMenuApi.cs
@@ -35,6 +35,15 @@ namespace GenericModConfigMenu
         /// <param name="text">The paragraph text to display.</param>
         void AddParagraph(IManifest mod, Func<string> text);
 
+        /// <summary>Add a boolean option at the current position in the form.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        /// <param name="getValue">Get the current value from the mod config.</param>
+        /// <param name="setValue">Set a new value in the mod config.</param>
+        /// <param name="name">The label text to show in the form.</param>
+        /// <param name="tooltip">The tooltip text shown when the cursor hovers on the field, or <c>null</c> to disable the tooltip.</param>
+        /// <param name="fieldId">The unique field ID for use with <see cref="OnFieldChanged"/>, or <c>null</c> to auto-generate a randomized ID.</param>
+        void AddBoolOption(IManifest mod, Func<bool> getValue, Action<bool> setValue, Func<string> name, Func<string> tooltip = null, string fieldId = null);
+
         /// <summary>Add an integer option at the current position in the form.</summary>
         /// <param name="mod">The mod's manifest.</param>
         /// <param name="getValue">Get the current value from the mod config.</param>

--- a/GiveMeMyCursorBack/manifest.json
+++ b/GiveMeMyCursorBack/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "Give Me My Cursor Back!",
   "Author": "DecidedlyHuman",
-  "Version": "0.0.4",
+  "Version": "1.1.1",
   "Description": "Are you tired of your cursor being invisible in the game window when alt-tabbed if you don't have the hardware cursor setting enabled? This solves that problem!",
   "UniqueID": "DecidedlyHuman.GiveMeMyCursorBack",
   "EntryDll": "GiveMeMyCursorBack.dll",

--- a/GiveMeMyCursorBack/manifest.json
+++ b/GiveMeMyCursorBack/manifest.json
@@ -1,10 +1,10 @@
 {
   "Name": "Give Me My Cursor Back!",
   "Author": "DecidedlyHuman",
-  "Version": "0.0.3",
+  "Version": "0.0.4",
   "Description": "Are you tired of your cursor being invisible in the game window when alt-tabbed if you don't have the hardware cursor setting enabled? This solves that problem!",
   "UniqueID": "DecidedlyHuman.GiveMeMyCursorBack",
   "EntryDll": "GiveMeMyCursorBack.dll",
-  "MinimumApiVersion": "3.0.0",
+  "MinimumApiVersion": "3.17.0",
   "UpdateKeys": ["Nexus:9976"]
 }

--- a/GiveMeMyCursorBack/packages.config
+++ b/GiveMeMyCursorBack/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="3.3.0" targetFramework="net452" />
-</packages>


### PR DESCRIPTION
Currently, with the latest version of GMCM the following warning appears upon launching:

`[Generic Mod Config Menu] DecidedlyHuman.GiveMeMyCursorBack (registering for DecidedlyHuman.GiveMeMyCursorBack) is using deprecated code (AddNumberOption(IManifest mod, Func<int> getValue, Action<int> setValue, Func<string> name = null, Func<string> tooltip = null, int? min = null, int? max = null, int? interval = null, string fieldId = null)) that will break in a future version of GMCM.`

This PR updates not only GMCM but also updates the project to target .net6 from .net4.

This also adds a toggle config for testing purposes.